### PR TITLE
declare littleEndianHexToDec as static function

### DIFF
--- a/public/polite.class.php
+++ b/public/polite.class.php
@@ -40,7 +40,7 @@ class Polite
         return substr($string, $offset * 2, $count * 2);
     }
 
-    public function littleEndianHexToDec(string $hexValue): int
+    public static function littleEndianHexToDec(string $hexValue): int
     {
         $bigEndianHex = implode('', array_reverse(str_split($hexValue, 2)));
         return hexdec($bigEndianHex);


### PR DESCRIPTION
function littleEndianHexToDec is only used as a static function. php 8.1 fails if you try to run a non static function static